### PR TITLE
Add defaults to configuration decorator

### DIFF
--- a/src/tiden/artifacts.py
+++ b/src/tiden/artifacts.py
@@ -393,7 +393,7 @@ def repack(artifact_name, src_path, checksum, work_dir, rules, artifacts_dir, ar
 
                 custom_name = artifacts[artifact_name].get('name')
                 new_zip_file_name = f'{custom_name}{data["pattern"]}' if custom_name else basename(src_path)
-                new_zip_file_name = new_zip_file_name.replace(data["pattern"], f'.repack.{data["pattern"]}')
+                new_zip_file_name = new_zip_file_name.replace(data["pattern"], f'.repack{data["pattern"]}')
                 new_zip_file = join(work_dir, new_zip_file_name)
 
         assert new_zip_file is not None, "Can't find unzip operation for {} file".format(basename(src_path))

--- a/src/tiden/configuration_decorator.py
+++ b/src/tiden/configuration_decorator.py
@@ -40,7 +40,7 @@ def test_configuration(*args):
 
         assert all(map(
             lambda c: isinstance(c, list),
-            configuration_options, configurations, configuration_defaults
+            (configuration_options, configurations, configuration_defaults)
         )), 'Test configuration accepts only lists'
 
         cls.__configuration_options__ = configuration_options.copy()

--- a/src/tiden/configuration_decorator.py
+++ b/src/tiden/configuration_decorator.py
@@ -41,13 +41,14 @@ def test_configuration(*args):
         assert all(map(
             lambda c: isinstance(c, list),
             configuration_options, configurations, configuration_defaults
-        ))
+        )), 'Test configuration accepts only lists'
 
         cls.__configuration_options__ = configuration_options.copy()
         cls.__configurations__ = configurations.copy()
 
         if configuration_defaults:
-            assert len(configuration_options) == len(configuration_defaults)
+            assert len(configuration_options) == len(configuration_defaults), \
+                'Please set defaults for all configuration options'
             cls.__configuration_defaults__ = configuration_defaults.copy()
 
         return cls

--- a/src/tiden/configuration_decorator.py
+++ b/src/tiden/configuration_decorator.py
@@ -18,6 +18,7 @@ from .generators import gen_permutations
 
 CONFIG_NOT_APPLICABLE_OPTION = 'CONFIG_NOT_APPLICABLE_OPTION'
 
+
 def test_configuration(*args):
     def test_configuration_decorator(cls):
         assert len(args) > 0
@@ -25,8 +26,6 @@ def test_configuration(*args):
         args0 = list(args)
         while len(args0) < 3:
             args0.append([])
-        assert all(map(lambda c: isinstance(c, list), args0))
-
         configuration_options, configurations, configuration_defaults = args0
 
         if not configurations:
@@ -39,6 +38,11 @@ def test_configuration(*args):
                 ])
             )
 
+        assert all(map(
+            lambda c: isinstance(c, list),
+            configuration_options, configurations, configuration_defaults
+        ))
+
         cls.__configuration_options__ = configuration_options.copy()
         cls.__configurations__ = configurations.copy()
 
@@ -48,4 +52,3 @@ def test_configuration(*args):
 
         return cls
     return test_configuration_decorator
-

--- a/src/tiden/configuration_decorator.py
+++ b/src/tiden/configuration_decorator.py
@@ -37,7 +37,7 @@ class test_configuration:
                 ])
             )
 
-        assert isinstance(self.possible_values, list) and isinstance(self.possible_values, list), \
+        assert isinstance(self.options, list) and isinstance(self.possible_values, list), \
             'Test configuration accepts only lists'
 
         if self.default_values:

--- a/src/tiden/configuration_decorator.py
+++ b/src/tiden/configuration_decorator.py
@@ -16,15 +16,18 @@
 
 from .generators import gen_permutations
 
-
 def test_configuration(*args):
     def test_configuration_decorator(cls):
         assert len(args) > 0
-        if len(args) >= 1:
-            configuration_options = args[0]
-        if len(args) >= 2:
-            configurations = args[1]
-        else:
+
+        args0 = list(args)
+        while len(args0) < 3:
+            args0.append([])
+        assert all(map(lambda c: isinstance(c, list), args0))
+
+        configuration_options, configurations, configuration_defaults = args0
+
+        if not configurations:
             configurations = list(
                 gen_permutations([
                     [True, False]
@@ -33,8 +36,14 @@ def test_configuration(*args):
                     if configuration_option.endswith('_enabled')
                 ])
             )
+
         cls.__configuration_options__ = configuration_options.copy()
         cls.__configurations__ = configurations.copy()
+
+        if configuration_defaults:
+            assert len(configuration_options) == len(configuration_defaults)
+            cls.__configuration_defaults__ = configuration_defaults.copy()
+
         return cls
     return test_configuration_decorator
 

--- a/src/tiden/configuration_decorator.py
+++ b/src/tiden/configuration_decorator.py
@@ -21,7 +21,7 @@ CONFIG_NOT_APPLICABLE_OPTION = 'CONFIG_NOT_APPLICABLE_OPTION'
 
 def test_configuration(*args):
     def test_configuration_decorator(cls):
-        assert len(args) > 0
+        assert len(args) > 0, 'Test configuration is empty'
 
         args0 = list(args)
         while len(args0) < 3:

--- a/src/tiden/configuration_decorator.py
+++ b/src/tiden/configuration_decorator.py
@@ -16,6 +16,8 @@
 
 from .generators import gen_permutations
 
+CONFIG_NOT_APPLICABLE_OPTION = 'CONFIG_NOT_APPLICABLE_OPTION'
+
 def test_configuration(*args):
     def test_configuration_decorator(cls):
         assert len(args) > 0

--- a/src/tiden/configuration_decorator.py
+++ b/src/tiden/configuration_decorator.py
@@ -19,37 +19,35 @@ from .generators import gen_permutations
 CONFIG_NOT_APPLICABLE_OPTION = 'CONFIG_NOT_APPLICABLE_OPTION'
 
 
-def test_configuration(*args):
-    def test_configuration_decorator(cls):
-        assert len(args) > 0, 'Test configuration is empty'
+class test_configuration:
+    def __init__(self, options: list, possible_values: list = None, default_values: list = None):
+        assert options, 'Test configuration is empty'
 
-        args0 = list(args)
-        while len(args0) < 3:
-            args0.append([])
-        configuration_options, configurations, configuration_defaults = args0
+        self.options = options
+        self.possible_values = possible_values
+        self.default_values = default_values
 
-        if not configurations:
-            configurations = list(
+        if not self.possible_values:
+            self.possible_values = list(
                 gen_permutations([
                     [True, False]
                     for configuration_option
-                    in configuration_options
+                    in options
                     if configuration_option.endswith('_enabled')
                 ])
             )
 
-        assert all(map(
-            lambda c: isinstance(c, list),
-            (configuration_options, configurations, configuration_defaults)
-        )), 'Test configuration accepts only lists'
+        assert isinstance(self.possible_values, list) and isinstance(self.possible_values, list), \
+            'Test configuration accepts only lists'
 
-        cls.__configuration_options__ = configuration_options.copy()
-        cls.__configurations__ = configurations.copy()
+        if self.default_values:
+            assert isinstance(self.default_values, list), 'Test configuration accepts only lists'
+            assert len(self.default_values) == len(self.options), 'Please set defaults for all configuration options'
 
-        if configuration_defaults:
-            assert len(configuration_options) == len(configuration_defaults), \
-                'Please set defaults for all configuration options'
-            cls.__configuration_defaults__ = configuration_defaults.copy()
+    def __call__(self, cls):
+        cls.__configuration_options__ = self.options
+        cls.__configurations__ = self.possible_values
+        if self.default_values:
+            cls.__configuration_defaults__ = self.default_values
 
         return cls
-    return test_configuration_decorator

--- a/src/tiden/plugins/envexpander.py
+++ b/src/tiden/plugins/envexpander.py
@@ -69,8 +69,9 @@ class EnvExpander(TidenPlugin):
                 output_config = {}
                 if len(var_values) == 0:
                     var_values = ['']
-                for var_value in var_values:
+                for i, var_value in enumerate(var_values):
                     env[var_name] = var_value
+                    env['EXPANDER_COUNTER'] = str(i + 1)
                     tmp_config = {}
                     self._patch_config_with_env(input_config, tmp_config, env)
                     mergedict(tmp_config, output_config)

--- a/src/tiden/runner.py
+++ b/src/tiden/runner.py
@@ -26,7 +26,7 @@ from shutil import rmtree
 import yaml
 
 from .tidenexception import TidenException
-from .util import log_print, print_red, cfg
+from .util import log_print, print_red, cfg, get_nested_key, set_nested_key
 
 
 def get_long_path_len(modules):
@@ -70,6 +70,12 @@ def get_configuration_representation(cfg_options, configuration):
         else:
             cfg_representation.append(cfg_option + '=' + "'" + str(configuration[i]) + "'")
     return '(' + ', '.join(cfg_representation) + ')'
+
+
+def set_default_configuration(config, cfg_options, default_values):
+    for cfg_option, default_value in zip(cfg_options, default_values):
+        if get_nested_key(config, cfg_option) is None:
+            set_nested_key(config, cfg_option, default_value)
 
 
 def get_actual_configuration(config, cfg_options):

--- a/src/tiden/runner.py
+++ b/src/tiden/runner.py
@@ -25,6 +25,7 @@ from shutil import rmtree
 
 import yaml
 
+from .configuration_decorator import CONFIG_NOT_APPLICABLE_OPTION
 from .tidenexception import TidenException
 from .util import log_print, print_red, cfg, get_nested_key, set_nested_key
 
@@ -79,14 +80,18 @@ def set_default_configuration(config, cfg_options, default_values):
 
 
 def get_actual_configuration(config, cfg_options):
-    configuration = []
+    actual_cfg_options = []
+    cfg_values = []
     for cfg_option in cfg_options:
         cfg_option_value = cfg(config, cfg_option)
+        if cfg_option_value == CONFIG_NOT_APPLICABLE_OPTION:
+            continue
         if cfg_option_value is None:
             raise TidenException(
-                "Expected configuration option '%s' not set, please pass its value with --to arg!" % cfg_option)
-        configuration.append(cfg_option_value)
-    return configuration
+                f"Expected configuration option '{cfg_option}' not set, please pass its value with --to arg!")
+        actual_cfg_options.append(cfg_option)
+        cfg_values.append(cfg_option_value)
+    return actual_cfg_options, cfg_values
 
 
 def get_test_modules(config, collect_only=False):

--- a/src/tiden/tidenrunner.py
+++ b/src/tiden/tidenrunner.py
@@ -28,7 +28,8 @@ from .sshpool import SshPool
 from uuid import uuid4
 from traceback import format_exc
 
-from .runner import set_configuration_options, get_configuration_representation, get_actual_configuration
+from .runner import set_configuration_options, get_configuration_representation, get_actual_configuration, \
+    set_default_configuration
 
 from importlib import import_module
 from os import path, mkdir, remove
@@ -209,6 +210,9 @@ class TidenRunner:
             # find test methods:
             if hasattr(self.test_class, '__configurations__'):
                 cfg_options = getattr(self.test_class, '__configuration_options__')
+                if hasattr(self.test_class, '__configuration_defaults__'):
+                    set_default_configuration(self.config, cfg_options,
+                                              getattr(self.test_class, '__configuration_defaults__'))
                 configuration = get_actual_configuration(self.config, cfg_options)
 
                 log_print("Configuration options for %s:\n%s" % (self.test_class.__class__.__name__,

--- a/src/tiden/tidenrunner.py
+++ b/src/tiden/tidenrunner.py
@@ -213,7 +213,7 @@ class TidenRunner:
                 if hasattr(self.test_class, '__configuration_defaults__'):
                     set_default_configuration(self.config, cfg_options,
                                               getattr(self.test_class, '__configuration_defaults__'))
-                configuration = get_actual_configuration(self.config, cfg_options)
+                cfg_options, configuration = get_actual_configuration(self.config, cfg_options)
 
                 log_print("Configuration options for %s:\n%s" % (self.test_class.__class__.__name__,
                                                                  '\n'.join([
@@ -364,7 +364,7 @@ class TidenRunner:
             if cfg_options is None:
                 cfg_options = getattr(self.test_class, '__configuration_options__')
             if configuration is None:
-                configuration = get_actual_configuration(self.config, cfg_options)
+                cfg_options, configuration = get_actual_configuration(self.config, cfg_options)
             configuration_representation = get_configuration_representation(cfg_options, configuration)
             self.current_test_name = self.current_test_method + configuration_representation
         else:


### PR DESCRIPTION
Usage example:
```
@test_configuration(
    # Config options
    ['persistence_enabled', 'sync_mode', 'wal_mode', 'cache_mode', 'ssl_enabled'],
    # Possible values
    list(gen_permutations([
        [True],
        ['FULL_SYNC', 'PRIMARY_SYNC'],
        ['NONE', 'FSYNC', 'LOG_ONLY', 'BACKGROUND'],
        ['PARTITIONED', 'REPLICATED'],
        [True, False]
    ])) + list(gen_permutations(([
        [False],
        ['FULL_SYNC', 'PRIMARY_SYNC'],
        [CONFIG_NOT_APPLICABLE_OPTION],
        ['PARTITIONED', 'REPLICATED'],
        [True, False]
    ]))),
    # Defaults
    [False, 'PRIMARY_SYNC', 'LOG_ONLY', 'PARTITIONED', False]
)
```